### PR TITLE
Bump httpclient from 4.5.8 to 4.5.13 in /apidoc-yapi-plugin

### DIFF
--- a/apidoc-yapi-plugin/pom.xml
+++ b/apidoc-yapi-plugin/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.8</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.5.8 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>