### PR TITLE
Bump commons-io from 2.6 to 2.7 in /apidoc-core

### DIFF
--- a/apidoc-core/pom.xml
+++ b/apidoc-core/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>